### PR TITLE
Refactor Test DTO to use List<String> instead of String for expectedOutput and userInput

### DIFF
--- a/src/main/kotlin/edu/ingsis/snippetmanager/test/Test.kt
+++ b/src/main/kotlin/edu/ingsis/snippetmanager/test/Test.kt
@@ -23,5 +23,5 @@ data class Test(
     val expectedOutput: List<String>,
     @ElementCollection
     @Column(nullable = false)
-    val userInput: List<String>
+    val userInput: List<String>,
 )

--- a/src/main/kotlin/edu/ingsis/snippetmanager/test/Test.kt
+++ b/src/main/kotlin/edu/ingsis/snippetmanager/test/Test.kt
@@ -18,10 +18,10 @@ data class Test(
     @ManyToOne
     @JoinColumn(name = "snippet_id", nullable = false)
     val snippet: Snippet,
-    @Column(nullable = false)
-    val expectedOutput: String,
-    @Column(nullable = false)
-    val userInput: String,
     @ElementCollection
-    val environmentVariables: Map<String, String> = emptyMap(),
+    @Column(nullable = false)
+    val expectedOutput: List<String>,
+    @ElementCollection
+    @Column(nullable = false)
+    val userInput: List<String>
 )

--- a/src/main/kotlin/edu/ingsis/snippetmanager/test/TestController.kt
+++ b/src/main/kotlin/edu/ingsis/snippetmanager/test/TestController.kt
@@ -5,7 +5,14 @@ import edu.ingsis.snippetmanager.test.dto.TestResponse
 import edu.ingsis.snippetmanager.test.dto.UpdateTestDTO
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/v1/tests")
@@ -13,30 +20,40 @@ class TestController(
     private val testService: TestService,
 ) {
     @GetMapping("/{id}")
-    fun getTest(@PathVariable id: Long): ResponseEntity<TestResponse> {
+    fun getTest(
+        @PathVariable id: Long,
+    ): ResponseEntity<TestResponse> {
         val test = testService.getTestById(id)
-        val response = TestResponse(
-            id = test.id,
-            expectedOutput = test.expectedOutput,
-            userInput = test.userInput
-        )
+        val response =
+            TestResponse(
+                id = test.id,
+                expectedOutput = test.expectedOutput,
+                userInput = test.userInput,
+            )
         return ResponseEntity.ok(response)
     }
 
     @PostMapping
-    fun createTest(@RequestBody dto: CreateTestDTO): ResponseEntity<Test> {
+    fun createTest(
+        @RequestBody dto: CreateTestDTO,
+    ): ResponseEntity<Test> {
         val test = testService.createTest(dto)
         return ResponseEntity.status(HttpStatus.CREATED).body(test)
     }
 
     @PutMapping("/{id}")
-    fun updateTest(@PathVariable id: Long, @RequestBody dto: UpdateTestDTO): ResponseEntity<Test> {
+    fun updateTest(
+        @PathVariable id: Long,
+        @RequestBody dto: UpdateTestDTO,
+    ): ResponseEntity<Test> {
         val test = testService.updateTest(id, dto)
         return ResponseEntity.ok(test)
     }
 
     @DeleteMapping("/{id}")
-    fun deleteTest(@PathVariable id: Long): ResponseEntity<Void> {
+    fun deleteTest(
+        @PathVariable id: Long,
+    ): ResponseEntity<Void> {
         testService.deleteTest(id)
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/edu/ingsis/snippetmanager/test/TestController.kt
+++ b/src/main/kotlin/edu/ingsis/snippetmanager/test/TestController.kt
@@ -5,14 +5,7 @@ import edu.ingsis.snippetmanager.test.dto.TestResponse
 import edu.ingsis.snippetmanager.test.dto.UpdateTestDTO
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/v1/tests")
@@ -20,41 +13,30 @@ class TestController(
     private val testService: TestService,
 ) {
     @GetMapping("/{id}")
-    fun getTest(
-        @PathVariable id: Long,
-    ): ResponseEntity<TestResponse> {
+    fun getTest(@PathVariable id: Long): ResponseEntity<TestResponse> {
         val test = testService.getTestById(id)
-        val response =
-            TestResponse(
-                id = test.id,
-                expectedOutput = test.expectedOutput,
-                userInput = test.userInput,
-                environmentVariables = test.environmentVariables,
-            )
+        val response = TestResponse(
+            id = test.id,
+            expectedOutput = test.expectedOutput,
+            userInput = test.userInput
+        )
         return ResponseEntity.ok(response)
     }
 
     @PostMapping
-    fun createTest(
-        @RequestBody dto: CreateTestDTO,
-    ): ResponseEntity<Test> {
+    fun createTest(@RequestBody dto: CreateTestDTO): ResponseEntity<Test> {
         val test = testService.createTest(dto)
         return ResponseEntity.status(HttpStatus.CREATED).body(test)
     }
 
     @PutMapping("/{id}")
-    fun updateTest(
-        @PathVariable id: Long,
-        @RequestBody dto: UpdateTestDTO,
-    ): ResponseEntity<Test> {
+    fun updateTest(@PathVariable id: Long, @RequestBody dto: UpdateTestDTO): ResponseEntity<Test> {
         val test = testService.updateTest(id, dto)
         return ResponseEntity.ok(test)
     }
 
     @DeleteMapping("/{id}")
-    fun deleteTest(
-        @PathVariable id: Long,
-    ): ResponseEntity<Void> {
+    fun deleteTest(@PathVariable id: Long): ResponseEntity<Void> {
         testService.deleteTest(id)
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/edu/ingsis/snippetmanager/test/TestRepository.kt
+++ b/src/main/kotlin/edu/ingsis/snippetmanager/test/TestRepository.kt
@@ -5,5 +5,5 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface TestRepository : JpaRepository<Test, Long> {
-    fun findBySnippetId(snippetId: Long): List<Test>
+    fun findBySnippetId(snippetId: Long): List<Test>?
 }

--- a/src/main/kotlin/edu/ingsis/snippetmanager/test/TestService.kt
+++ b/src/main/kotlin/edu/ingsis/snippetmanager/test/TestService.kt
@@ -20,27 +20,34 @@ class TestService(
 
     @Transactional
     fun createTest(dto: CreateTestDTO): Test {
-        val snippet = snippetRepository.findSnippetById(dto.snippetId)
-            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Snippet not found")
+        val snippet =
+            snippetRepository.findSnippetById(dto.snippetId)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Snippet not found")
 
-        val test = Test(
-            snippet = snippet,
-            expectedOutput = dto.expectedOutput,
-            userInput = dto.userInput
-        )
+        val test =
+            Test(
+                snippet = snippet,
+                expectedOutput = dto.expectedOutput,
+                userInput = dto.userInput,
+            )
 
         return testRepository.save(test)
     }
 
     @Transactional
-    fun updateTest(id: Long, dto: UpdateTestDTO): Test {
-        val test = testRepository.findById(id)
-            .orElseThrow { throw ResponseStatusException(HttpStatus.NOT_FOUND, "Test not found") }
+    fun updateTest(
+        id: Long,
+        dto: UpdateTestDTO,
+    ): Test {
+        val test =
+            testRepository.findById(id)
+                .orElseThrow { throw ResponseStatusException(HttpStatus.NOT_FOUND, "Test not found") }
 
-        val updatedTest = test.copy(
-            expectedOutput = dto.expectedOutput,
-            userInput = dto.userInput,
-        )
+        val updatedTest =
+            test.copy(
+                expectedOutput = dto.expectedOutput,
+                userInput = dto.userInput,
+            )
 
         return testRepository.save(updatedTest)
     }

--- a/src/main/kotlin/edu/ingsis/snippetmanager/test/TestService.kt
+++ b/src/main/kotlin/edu/ingsis/snippetmanager/test/TestService.kt
@@ -15,42 +15,32 @@ class TestService(
 ) {
     fun getTestById(id: Long): Test {
         return testRepository.findById(id)
-            .map { it.apply { environmentVariables } }
             .orElseThrow { throw ResponseStatusException(HttpStatus.NOT_FOUND, "Test not found with id $id") }
     }
 
     @Transactional
     fun createTest(dto: CreateTestDTO): Test {
-        val snippet =
-            snippetRepository.findById(dto.snippetId)
-                .orElseThrow { throw ResponseStatusException(HttpStatus.NOT_FOUND, "Snippet not found") }
+        val snippet = snippetRepository.findSnippetById(dto.snippetId)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Snippet not found")
 
-        val test =
-            Test(
-                snippet = snippet,
-                expectedOutput = dto.expectedOutput,
-                userInput = dto.userInput,
-                environmentVariables = dto.environmentVariables,
-            )
+        val test = Test(
+            snippet = snippet,
+            expectedOutput = dto.expectedOutput,
+            userInput = dto.userInput
+        )
 
         return testRepository.save(test)
     }
 
     @Transactional
-    fun updateTest(
-        id: Long,
-        dto: UpdateTestDTO,
-    ): Test {
-        val test =
-            testRepository.findById(id)
-                .orElseThrow { throw ResponseStatusException(HttpStatus.NOT_FOUND, "Test not found") }
+    fun updateTest(id: Long, dto: UpdateTestDTO): Test {
+        val test = testRepository.findById(id)
+            .orElseThrow { throw ResponseStatusException(HttpStatus.NOT_FOUND, "Test not found") }
 
-        val updatedTest =
-            test.copy(
-                expectedOutput = dto.expectedOutput,
-                userInput = dto.userInput,
-                environmentVariables = dto.environmentVariables,
-            )
+        val updatedTest = test.copy(
+            expectedOutput = dto.expectedOutput,
+            userInput = dto.userInput,
+        )
 
         return testRepository.save(updatedTest)
     }

--- a/src/main/kotlin/edu/ingsis/snippetmanager/test/dto/CreateTestDTO.kt
+++ b/src/main/kotlin/edu/ingsis/snippetmanager/test/dto/CreateTestDTO.kt
@@ -2,7 +2,6 @@ package edu.ingsis.snippetmanager.test.dto
 
 data class CreateTestDTO(
     val snippetId: Long,
-    val expectedOutput: String,
-    val userInput: String,
-    val environmentVariables: Map<String, String> = emptyMap(),
+    val expectedOutput: List<String>,
+    val userInput: List<String>,
 )

--- a/src/main/kotlin/edu/ingsis/snippetmanager/test/dto/TestResponse.kt
+++ b/src/main/kotlin/edu/ingsis/snippetmanager/test/dto/TestResponse.kt
@@ -2,7 +2,6 @@ package edu.ingsis.snippetmanager.test.dto
 
 data class TestResponse(
     val id: Long,
-    val expectedOutput: String,
-    val userInput: String,
-    val environmentVariables: Map<String, String>,
+    val expectedOutput: List<String>,
+    val userInput: List<String>,
 )

--- a/src/main/kotlin/edu/ingsis/snippetmanager/test/dto/UpdateTestDTO.kt
+++ b/src/main/kotlin/edu/ingsis/snippetmanager/test/dto/UpdateTestDTO.kt
@@ -1,7 +1,6 @@
 package edu.ingsis.snippetmanager.test.dto
 
 data class UpdateTestDTO(
-    val expectedOutput: String,
-    val userInput: String,
-    val environmentVariables: Map<String, String> = emptyMap(),
+    val expectedOutput: List<String>,
+    val userInput: List<String>,
 )

--- a/src/test/kotlin/edu/ingsis/snippetmanager/test/TestControllerE2ETests.kt
+++ b/src/test/kotlin/edu/ingsis/snippetmanager/test/TestControllerE2ETests.kt
@@ -18,7 +18,6 @@ import org.springframework.test.web.reactive.server.WebTestClient
 @ExtendWith(SpringExtension::class)
 @ActiveProfiles("test")
 class TestControllerE2ETests {
-
     @Autowired
     lateinit var client: WebTestClient
 
@@ -30,21 +29,23 @@ class TestControllerE2ETests {
 
     @BeforeEach
     fun setup() {
-        val snippet = Snippet(
-            name = "Test Snippet",
-            description = "A snippet for testing",
-            language = "printscript",
-            version = "1.1",
-            extension = "ps"
-        )
+        val snippet =
+            Snippet(
+                name = "Test Snippet",
+                description = "A snippet for testing",
+                language = "printscript",
+                version = "1.1",
+                extension = "ps",
+            )
 
         val savedSnippet = snippetRepository.save(snippet)
 
-        val test = Test(
-            snippet = savedSnippet,
-            expectedOutput = listOf("Expected Output Line 1", "Expected Output Line 2"),
-            userInput = listOf("User Input Line 1", "User Input Line 2")
-        )
+        val test =
+            Test(
+                snippet = savedSnippet,
+                expectedOutput = listOf("Expected Output Line 1", "Expected Output Line 2"),
+                userInput = listOf("User Input Line 1", "User Input Line 2"),
+            )
 
         testRepository.save(test)
     }
@@ -59,11 +60,12 @@ class TestControllerE2ETests {
     fun `should create Test`() {
         val snippetId = snippetRepository.findAll().first().id!!
 
-        val dto = CreateTestDTO(
-            snippetId = snippetId,
-            expectedOutput = listOf("Expected Output Line 1", "Expected Output Line 2"),
-            userInput = listOf("User Input Line 1", "User Input Line 2")
-        )
+        val dto =
+            CreateTestDTO(
+                snippetId = snippetId,
+                expectedOutput = listOf("Expected Output Line 1", "Expected Output Line 2"),
+                userInput = listOf("User Input Line 1", "User Input Line 2"),
+            )
 
         client.post().uri(BASE)
             .bodyValue(dto)
@@ -80,10 +82,11 @@ class TestControllerE2ETests {
     @Test
     fun `should update Test`() {
         val test = testRepository.findAll().first()
-        val dto = UpdateTestDTO(
-            expectedOutput = listOf("Updated Expected Output Line 1", "Updated Expected Output Line 2"),
-            userInput = listOf("Updated User Input Line 1", "Updated User Input Line 2")
-        )
+        val dto =
+            UpdateTestDTO(
+                expectedOutput = listOf("Updated Expected Output Line 1", "Updated Expected Output Line 2"),
+                userInput = listOf("Updated User Input Line 1", "Updated User Input Line 2"),
+            )
 
         client.put().uri("$BASE/${test.id}")
             .bodyValue(dto)

--- a/src/test/kotlin/edu/ingsis/snippetmanager/test/TestFixtures.kt
+++ b/src/test/kotlin/edu/ingsis/snippetmanager/test/TestFixtures.kt
@@ -8,12 +8,12 @@ object TestFixtures {
             Test(
                 snippet = snippet,
                 expectedOutput = listOf("Expected Output Line 1", "Expected Output Line 2"),
-                userInput = listOf("User Input Line 1", "User Input Line 2")
+                userInput = listOf("User Input Line 1", "User Input Line 2"),
             ),
             Test(
                 snippet = snippet,
                 expectedOutput = listOf("Expected Output Line 3", "Expected Output Line 4"),
-                userInput = listOf("User Input Line 3", "User Input Line 4")
-            )
+                userInput = listOf("User Input Line 3", "User Input Line 4"),
+            ),
         )
 }

--- a/src/test/kotlin/edu/ingsis/snippetmanager/test/TestFixtures.kt
+++ b/src/test/kotlin/edu/ingsis/snippetmanager/test/TestFixtures.kt
@@ -7,15 +7,13 @@ object TestFixtures {
         listOf(
             Test(
                 snippet = snippet,
-                expectedOutput = "Expected Output 1",
-                userInput = "User Input 1",
-                environmentVariables = mapOf("ENV_VAR1" to "value1"),
+                expectedOutput = listOf("Expected Output Line 1", "Expected Output Line 2"),
+                userInput = listOf("User Input Line 1", "User Input Line 2")
             ),
             Test(
                 snippet = snippet,
-                expectedOutput = "Expected Output 2",
-                userInput = "User Input 2",
-                environmentVariables = mapOf("ENV_VAR2" to "value2"),
-            ),
+                expectedOutput = listOf("Expected Output Line 3", "Expected Output Line 4"),
+                userInput = listOf("User Input Line 3", "User Input Line 4")
+            )
         )
 }


### PR DESCRIPTION
### Summary
This PR refactors the `CreateTestDTO` and other related DTOs to replace `String` with `List<String>` for the `expectedOutput` and `userInput` fields. This change allows tests to handle multiple lines or items in expected output and user input.

### Changes
- Updated `CreateTestDTO` and `TestResponse` to use `List<String>` for `expectedOutput` and `userInput`.
- Modified the service and controller layers to work with the new structure.
- Refactored all methods, variables, and test cases affected by this change.

### Testing
- All existing tests have been updated and successfully executed to verify compatibility with the new data structure.
  
Please review the changes and confirm that the refactoring meets the new requirements.
